### PR TITLE
Allows Glow_ink_sac to be used on wall signs next to containers; not just DyeItems

### DIFF
--- a/fabric/src/main/java/com/girafi/passthroughsigns/util/PassableHandler.java
+++ b/fabric/src/main/java/com/girafi/passthroughsigns/util/PassableHandler.java
@@ -10,7 +10,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.decoration.Painting;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.DyeItem;
+import net.minecraft.world.item.SignApplicator;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
@@ -28,7 +28,7 @@ public class PassableHandler {
         ItemStack heldStack = player.getMainHandItem();
         if (hand == InteractionHand.MAIN_HAND && (block instanceof WallSignBlock && GENERAL.shouldWallSignBePassable.get() || block instanceof WallBannerBlock && GENERAL.shouldBannerBePassable.get() ||
                 block instanceof IPassable && ((IPassable) block).canBePassed(level, pos, IPassable.EnumPassableType.WALL_BLOCK) ||
-                PassthroughSignsAPI.BLOCK_PASSABLES.contains(block)) && !(heldStack.getItem() instanceof DyeItem)) {
+                PassthroughSignsAPI.BLOCK_PASSABLES.contains(block)) && !(heldStack.getItem() instanceof SignApplicator)) {
             Direction facingOpposite = Direction.NORTH.getOpposite();
             if (state.hasProperty(DirectionalBlock.FACING)) {
                 facingOpposite = state.getValue(DirectionalBlock.FACING).getOpposite();

--- a/neoforge/src/main/java/com/girafi/passthroughsigns/util/PassableHandler.java
+++ b/neoforge/src/main/java/com/girafi/passthroughsigns/util/PassableHandler.java
@@ -10,7 +10,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.decoration.ItemFrame;
 import net.minecraft.world.entity.decoration.Painting;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.DyeItem;
+import net.minecraft.world.item.SignApplicator;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
@@ -37,7 +37,7 @@ public class PassableHandler {
         InteractionHand hand = event.getHand();
         if (hand == InteractionHand.MAIN_HAND && (block instanceof WallSignBlock && GENERAL.shouldWallSignBePassable.get() || block instanceof WallBannerBlock && GENERAL.shouldBannerBePassable.get() ||
                 block instanceof IPassable && ((IPassable) block).canBePassed(level, pos, IPassable.EnumPassableType.WALL_BLOCK) ||
-                PassthroughSignsAPI.BLOCK_PASSABLES.contains(block)) && !(heldStack.getItem() instanceof DyeItem)) {
+                PassthroughSignsAPI.BLOCK_PASSABLES.contains(block)) && !(heldStack.getItem() instanceof SignApplicator)) {
             Direction facingOpposite = Direction.NORTH.getOpposite();
             if (state.hasProperty(DirectionalBlock.FACING)) {
                 facingOpposite = state.getValue(DirectionalBlock.FACING).getOpposite();


### PR DESCRIPTION
uses SignApplicator for the held item check instead of DyeItem. This is more future proof and robust since both DyeItem and GlowInkSacItem classes extend Item and implement SignApplicator

- for NeoForge and Fabric